### PR TITLE
Update IMDB dataset url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ found at [http://www.imdb.com/interfaces](http://www.imdb.com/interfaces)
 1. download `*gz` files (unpacking not necessary)
 
   ```sh
-  wget ftp://ftp.fu-berlin.de/pub/misc/movies/database/*gz
+  wget ftp://ftp.fu-berlin.de/pub/misc/movies/database/frozendata/*gz
   ```
   
 2. download and unpack `imdbpy` and the `imdbpy2sql.py` script


### PR DESCRIPTION
The dataset has changed and is now available at another address, as mentioned in ftp://ftp.fu-berlin.de/pub/misc/movies/database/README . 
The old dataset (that was used in this project) is still available for now, at the address ftp://ftp.fu-berlin.de/pub/misc/movies/database/frozendata/ .
Not sure how long it will be available, though.