### PR TITLE
Adjust some aliases from character to character_name to suit MySQL/TiDB.

### DIFF
--- a/10a.sql
+++ b/10a.sql
@@ -1,4 +1,4 @@
-SELECT MIN(chn.name) AS uncredited_voiced_character,
+SELECT MIN(chn.name) AS uncredited_voiced_character_name,
        MIN(t.title) AS russian_movie
 FROM char_name AS chn,
      cast_info AS ci,

--- a/10b.sql
+++ b/10b.sql
@@ -1,4 +1,4 @@
-SELECT MIN(chn.name) AS character,
+SELECT MIN(chn.name) AS character_name,
        MIN(t.title) AS russian_mov_with_actor_producer
 FROM char_name AS chn,
      cast_info AS ci,

--- a/10c.sql
+++ b/10c.sql
@@ -1,4 +1,4 @@
-SELECT MIN(chn.name) AS character,
+SELECT MIN(chn.name) AS character_name,
        MIN(t.title) AS movie_with_american_producer
 FROM char_name AS chn,
      cast_info AS ci,

--- a/9b.sql
+++ b/9b.sql
@@ -1,5 +1,5 @@
 SELECT MIN(an.name) AS alternative_name,
-       MIN(chn.name) AS voiced_character,
+       MIN(chn.name) AS voiced_character_name,
        MIN(n.name) AS voicing_actress,
        MIN(t.title) AS american_movie
 FROM aka_name AS an,

--- a/9d.sql
+++ b/9d.sql
@@ -1,5 +1,5 @@
 SELECT MIN(an.name) AS alternative_name,
-       MIN(chn.name) AS voiced_char_name,
+       MIN(chn.name) AS voiced_character_name,
        MIN(n.name) AS voicing_actress,
        MIN(t.title) AS american_movie
 FROM aka_name AS an,


### PR DESCRIPTION
Because **character** is in the  [keywords and reserved words list of mysql](https://dev.mysql.com/doc/refman/8.0/en/keywords.html),adjust it from **character** to  **character_name** (10b,10c)to suit MySQL(TiDB).
Also make some adjustment to unify aliases' name,like
  **voiced_character** to **voiced_character_name**(9b),
**voiced_char_name** to **voiced_character_name**(9d),
**uncredited_voiced_character** to **uncredited_voiced_character_name**(10a).

error output of 10b in tidb v4.0.8:
```
You have an error in your SQL syntax; check the manual that corresponds to your
 TiDB version for the right syntax to use line 1 column 49 near "character,
       MIN(t.title) AS russian_mov_with_actor_producer
FROM char_name AS chn,
     cast_info AS ci,
     company_name AS cn,
     company_type AS ct,
     movie_companies AS mc,
     role_type AS rt,
     title AS t
WHERE ci.note LIKE '%(producer)%'
  AND cn.country_code = '[ru]'
  AND rt.role = 'actor'
  AND t.production_year > 2010
  AND t.id = mc.movi
```
error output of 10b in tidb v4.0.8:
```
You have an error in your SQL syntax; check the manual that corresponds to your 
TiDB version for the right syntax to use line 1 column 49 near "character,
       MIN(t.title) AS movie_with_american_producer
FROM char_name AS chn,
     cast_info AS ci,
     company_name AS cn,
     company_type AS ct,
     movie_companies AS mc,
     role_type AS rt,
     title AS t
WHERE ci.note LIKE '%(producer)%'
  AND cn.country_code = '[us]'
  AND t.production_year > 1990
  AND t.id = mc.movie_id
  AND t.id = ci.movie_
```